### PR TITLE
マイページから投稿詳細への遷移先を修正

### DIFF
--- a/app/views/dreams/show.html.erb
+++ b/app/views/dreams/show.html.erb
@@ -28,6 +28,10 @@
             <td>❤◯件</td>
             <td>コメント◯件</td>
           </tr>
+          <tr>
+            <td><%= @dream.title %></td>
+            <td><%= @dream.body %></td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,7 +23,7 @@
         <% @dreams.each do |dream| %>
           <tr>
             <td>
-              <%= link_to dream_path(@dream.id) do %>
+              <%= link_to dream_path(dream.id) do %>
                 <%= dream.title %>
               <% end %>
             </td>


### PR DESCRIPTION
マイページから投稿詳細への遷移先を修正しました。
- 引数の＠を削除

投稿詳細にtitleとbodyを追加しました。