### PR TITLE
Userモデルのimageカラム名の修正

### DIFF
--- a/db/migrate/20210110085132_rename_image_id_column_to_users.rb
+++ b/db/migrate/20210110085132_rename_image_id_column_to_users.rb
@@ -1,0 +1,5 @@
+class RenameImageIdColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :users, :image_id, :image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_08_023724) do
+ActiveRecord::Schema.define(version: 2021_01_10_085132) do
 
   create_table "comments", force: :cascade do |t|
     t.integer "user_id"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2021_01_08_023724) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "username"
-    t.string "image_id"
+    t.string "image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Userモデルのimageカラム名の修正をしました。
- [rails generate migration rename_[変更前のカラム名]_column_to_[モデル名(複数形)]](https://qiita.com/libertyu/items/93acd8733e34b1d0a63c)